### PR TITLE
Client side events

### DIFF
--- a/events/collector.py
+++ b/events/collector.py
@@ -122,8 +122,14 @@ class EventCollector(object):
             self.error_queue.put(error)
             return HTTPBadRequest("no user-agent provided")
 
-        signature_header = request.headers.get("X-Signature", "")
-        keyname, mac = parse_signature(signature_header)
+        try:
+            signature_header = request.headers["X-Signature"]
+        except KeyError:
+            keyname = request.GET.get("key", "")
+            mac = request.GET.get("mac", "")
+        else:
+            keyname, mac = parse_signature(signature_header)
+
         key = self.keystore.get(keyname, "INVALID")
         body = request.body
         expected_mac = hmac.new(key, body, hashlib.sha256).hexdigest()

--- a/events/collector.py
+++ b/events/collector.py
@@ -22,6 +22,13 @@ from events import stats, queue
 _MAXIMUM_CONTENT_LENGTH = 40 * 1024
 _MAXIMUM_EVENT_SIZE = 5120  # extra padding over spec for our wrapper
 _LOG = logging.getLogger(__name__)
+_CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Max-Age": "1728000",  # 20 days
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "X-Signature",
+    "Vary": "Origin",
+}
 
 
 def is_subdomain(domain, base_domain):
@@ -117,6 +124,34 @@ class EventCollector(object):
         self.error_queue = error_queue
         self.allowed_origins = allowed_origins
 
+    def check_cors(self, request):
+        try:
+            origin = request.headers["Origin"]
+            requested_method = request.headers["Access-Control-Request-Method"]
+        except KeyError:
+            self.stats_client.count("cors.preflight.missing_headers")
+            raise HTTPForbidden()
+
+        headers_list = request.headers.get("Access-Control-Request-Headers", "")
+        requested_headers = [h.strip().lower() for h in headers_list.split(",")]
+        if requested_headers and requested_headers != ["x-signature"]:
+            self.stats_client.count("cors.preflight.bad_requested_headers")
+            raise HTTPForbidden()
+
+        if requested_method != "POST":
+            self.stats_client.count("cors.preflight.bad_method")
+            raise HTTPForbidden()
+
+        if not origin or not is_allowed_origin(origin, self.allowed_origins):
+            self.stats_client.count("cors.preflight.bad_origin")
+            raise HTTPForbidden()
+
+        self.stats_client.count("cors.preflight.allowed")
+        return Response(
+            status="204 No Content",
+            headers=_CORS_HEADERS,
+        )
+
     def process_request(self, request):
         """Consume an event batch request and return an appropriate response.
 
@@ -199,13 +234,9 @@ class EventCollector(object):
         self.stats_client.count("collected.http", count=len(reserialized_items))
 
         headers = {}
-
         origin = request.headers.get("Origin")
         if origin and is_allowed_origin(origin, self.allowed_origins):
-            headers.update({
-                "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Methods": "POST",
-            })
+            headers.update(_CORS_HEADERS)
 
         return Response(headers=headers)
 
@@ -239,7 +270,9 @@ def make_app(global_config, **settings):
     collector = EventCollector(
         keystore, stats_client, event_queue, error_queue, allowed_origins)
     config.add_route("v1", "/v1", request_method="POST")
+    config.add_route("v1_options", "/v1", request_method="OPTIONS")
     config.add_view(collector.process_request, route_name="v1")
+    config.add_view(collector.check_cors, route_name="v1_options")
     config.add_route("health", "/health")
     config.add_view(health_check, route_name="health", renderer="json")
 

--- a/example.ini
+++ b/example.ini
@@ -1,0 +1,62 @@
+[app:main]
+use = egg:eventcollector
+
+; pyramid configuration
+; http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
+pyramid.reload_templates = false
+pyramid.debug_authorization = false
+pyramid.debug_notfound = false
+pyramid.debug_routematch = false
+pyramid.default_locale_name = en
+
+; "secret" keys for the HMAC signature. base64 encoded.
+key.Example = dGhpcyBpcyBqdXN0IGFuIGV4YW1wbGUsIGRvbid0IHVzZSBtZQ==
+
+; the sysv message queue key for each queue
+msgq.events = 0x01
+msgq.errors = 0x02
+
+; the kinesis stream to send to for each queue
+topic.events = Events
+topic.errors = Errors
+
+; which kinesis region to connect to
+aws.region = us-west-2
+
+; a list of origins which are given CORS authorization, may be "*" for "all
+; origins" or a comma-delimited list of domains. all subdomains of given
+; domains are also accepted.
+allowed_origins = *
+
+[server:main]
+use = egg:gunicorn#main
+bind = unix:/run/events.socket
+workers = 4
+
+; logging http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+[loggers]
+keys = root, events
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_events]
+level = WARN
+handlers =
+qualname = events
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/tests/collector_tests.py
+++ b/tests/collector_tests.py
@@ -183,3 +183,23 @@ class CollectorUnitTests(unittest.TestCase):
         self.assertEquals(response.status_code, 413)
         self.assertEqual(len(self.event_sink.events), 0)
         self.assertEqual(len(self.error_sink.events), 1)
+
+    def test_key_in_urlparams(self):
+        request = testing.DummyRequest()
+        request.headers["User-Agent"] = "TestApp/1.0"
+        request.GET["key"] = "TestKey1"
+        request.GET["mac"] = "d7aab40b9db8ae0e0b40d98e9c50b2cfc80ca06127b42fbbbdf146752b47a5ed"
+        request.headers["Date"] = "Wed, 25 Nov 2015 06:25:24 GMT"
+        request.environ["REMOTE_ADDR"] = "1.2.3.4"
+        request.body = '[{"event1": "value"}, {"event2": "value"}]'
+        request.content_length = len(request.body)
+        response = self.collector.process_request(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [
+                '{"ip": "1.2.3.4", "event": {"event1": "value"}, "time": "2015-11-17T12:34:56"}',
+                '{"ip": "1.2.3.4", "event": {"event2": "value"}, "time": "2015-11-17T12:34:56"}',
+            ],
+            self.event_sink.events)
+        self.assertEqual(self.error_sink.events, [])

--- a/tests/collector_tests.py
+++ b/tests/collector_tests.py
@@ -251,3 +251,21 @@ class CollectorUnitTests(unittest.TestCase):
         response = self.collector.process_request(request)
 
         self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), None)
+
+    def test_text_plain(self):
+        # we need text/plain to work, even though it's gross and icky here, so
+        # that we can avoid a CORS preflight
+        self.allowed_origins.append("example.com")
+
+        request = testing.DummyRequest()
+        request.headers["User-Agent"] = "TestApp/1.0"
+        request.headers["X-Signature"] = "key=TestKey1, mac=d7aab40b9db8ae0e0b40d98e9c50b2cfc80ca06127b42fbbbdf146752b47a5ed"
+        request.headers["Date"] = "Wed, 25 Nov 2015 06:25:24 GMT"
+        request.headers["Origin"] = "https://www.example.com"
+        request.headers["Content-Type"] = "text/plain"
+        request.environ["REMOTE_ADDR"] = "1.2.3.4"
+        request.body = '[{"event1": "value"}, {"event2": "value"}]'
+        request.content_length = len(request.body)
+        response = self.collector.process_request(request)
+
+        self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -19,6 +19,7 @@ class CollectorFunctionalTests(unittest.TestCase):
             "key.TestKey1": "dGVzdA==",
             "msgq.events": "0xcafe",
             "msgq.errors": "0xdecaf",
+            "allowed_origins": "",
         })
         self.test_app = webtest.TestApp(app)
         self.events_queue = queue.SysVMessageQueue(key=0xcafe)

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -19,7 +19,7 @@ class CollectorFunctionalTests(unittest.TestCase):
             "key.TestKey1": "dGVzdA==",
             "msgq.events": "0xcafe",
             "msgq.errors": "0xdecaf",
-            "allowed_origins": "",
+            "allowed_origins": "example.com",
         })
         self.test_app = webtest.TestApp(app)
         self.events_queue = queue.SysVMessageQueue(key=0xcafe)
@@ -50,3 +50,12 @@ class CollectorFunctionalTests(unittest.TestCase):
 
         with self.assertRaises(sysv_ipc.BusyError):
             self.errors_queue.queue.receive(block=False)
+
+    def test_cors(self):
+        response = self.test_app.options("/v1", headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Signature",
+        })
+
+        self.assertEqual(response.status_code, 204)


### PR DESCRIPTION
This adds a few tweaks to make client-side events more palatable.  Specifically, it enables CORS and does some gymnastics to avoid extra requests via preflights.

According to [the MDN docs on preflighting](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests), a request will be preflighted if:

* "It uses methods other than GET, HEAD or POST."
    * We're good here, just POST.
* "Also, if POST is used to send request data with a Content-Type other than application/x-www-form-urlencoded, multipart/form-data, or text/plain"
    * Uh oh! We're doing `application/json`.  The last commit in this PR adds a test which asserts that `text/plain` works even though it's technically incorrect.  We weren't checking the `Content-Type` anywhere so it doesn't _really_ matter.  I know, I know.
* "It sets custom headers in the request (e.g. the request uses a header such as X-PINGOTHER)"
    * Uh oh again! `X-Signature`.  We'll allow the payload of `X-Signature` to be sent in the query parameters to avoid this issue.

Also, uh, I forgot to add the example.ini I wrote a while ago. It's getting included now.

:eyeglasses: @JordanMilne @ajacksified @umbrae 

cc: @Kaitaan 