### PR TITLE
Increase the size limits on events and event batches

### DIFF
--- a/events/collector.py
+++ b/events/collector.py
@@ -19,8 +19,8 @@ from pyramid.response import Response
 from events import stats, queue
 
 
-_MAXIMUM_CONTENT_LENGTH = 40 * 1024
-_MAXIMUM_EVENT_SIZE = 5120  # extra padding over spec for our wrapper
+_MAXIMUM_CONTENT_LENGTH = 500 * 1024
+_MAXIMUM_EVENT_SIZE = 100 * 1024  # extra padding over spec for our wrapper
 _LOG = logging.getLogger(__name__)
 _CORS_HEADERS = {
     "Access-Control-Allow-Origin": "*",

--- a/events/injector.py
+++ b/events/injector.py
@@ -32,9 +32,9 @@ boto.kinesis.regions = patched_regions
 
 
 # maximum size of a single record in kinesis (bytes)
-_MAX_RECORD_LEN = 51200
+_MAX_RECORD_LEN = 1024 * 1024
 # maximum delay while trying to build a larger batch (seconds)
-_MAX_WAIT = 5
+_MAX_WAIT = 3
 # exponential backoff for when exceeding provisioned throughput (seconds)
 _BASE_RETRY = 2
 

--- a/tests/collector_tests.py
+++ b/tests/collector_tests.py
@@ -82,7 +82,7 @@ class CollectorUnitTests(unittest.TestCase):
     def test_max_length_enforced(self):
         request = testing.DummyRequest()
         request.environ["REMOTE_ADDR"] = "1.2.3.4"
-        request.content_length = 50 * 1024
+        request.content_length = 500 * 1024
         response = self.collector.process_request(request)
         self.assertEqual(response.status_code, 413)
         self.assertEqual(len(self.event_sink.events), 0)


### PR DESCRIPTION
Increasing size limits to avoid unnecessary truncation for submit and comment events
  * Incoming events can now be up to 100 KB in size
  * Incoming batches can now be up to 500 KB in size
  * Outgoing batches to Kinesis can now be up to 1 MB in size

Decrease max time before flush. Increased size limits mean less frequent flushing,
so decrease the flush time to compensate.

:eyeglasses: @spladug 