### PR TITLE
collector: Remove check for Date header

### DIFF
--- a/events/collector.py
+++ b/events/collector.py
@@ -175,12 +175,6 @@ class EventCollector(object):
             self.error_queue.put(error)
             return HTTPRequestEntityTooLarge()
 
-        if not request.headers.get("Date"):
-            self.stats_client.count("client-error.no-date")
-            error = make_error_event(request, "NO_DATE")
-            self.error_queue.put(error)
-            return HTTPBadRequest("no date provided")
-
         if not request.headers.get("User-Agent"):
             self.stats_client.count("client-error.no-useragent")
             error = make_error_event(request, "NO_USERAGENT")

--- a/tests/collector_tests.py
+++ b/tests/collector_tests.py
@@ -158,9 +158,9 @@ class CollectorUnitTests(unittest.TestCase):
         request.body = '[{"event1": "value"}, {"event2": "value"}]'
         request.content_length = len(request.body)
         response = self.collector.process_request(request)
-        self.assertEquals(response.status_code, 400)
-        self.assertEqual(len(self.event_sink.events), 0)
-        self.assertEqual(len(self.error_sink.events), 1)
+        self.assertEquals(response.status_code, 200)
+        self.assertEqual(len(self.event_sink.events), 2)
+        self.assertEqual(len(self.error_sink.events), 0)
 
     def test_useragent_not_provided(self):
         request = testing.DummyRequest()


### PR DESCRIPTION
Unfortunately, Date is one of the protected headers that XHR cannot
send. We're not currently using this, it was just there for
future-proofing, so we can remove the check for now.

http://www.w3.org/TR/XMLHttpRequest/#the-setrequestheader()-method

:eyeglasses: @florenceyeun @Kaitaan 