### PR TITLE
Centralize max event size

### DIFF
--- a/events/collector.py
+++ b/events/collector.py
@@ -17,10 +17,10 @@ from pyramid.httpexceptions import (
 from pyramid.response import Response
 
 from events import stats, queue
+from .const import MAXIMUM_EVENT_SIZE
 
 
 _MAXIMUM_CONTENT_LENGTH = 500 * 1024
-_MAXIMUM_EVENT_SIZE = 100 * 1024  # extra padding over spec for our wrapper
 _LOG = logging.getLogger(__name__)
 _CORS_HEADERS = {
     "Access-Control-Allow-Origin": "*",
@@ -215,7 +215,7 @@ class EventCollector(object):
         reserialized_items = []
         for item in batch:
             reserialized = wrap_and_serialize_event(request, item)
-            if len(reserialized) > _MAXIMUM_EVENT_SIZE:
+            if len(reserialized) > MAXIMUM_EVENT_SIZE:
                 self.stats_client.count("client-error.too-big")
                 error = make_error_event(request, "EVENT_TOO_BIG")
                 self.error_queue.put(error)

--- a/events/const.py
+++ b/events/const.py
@@ -1,0 +1,1 @@
+MAXIMUM_EVENT_SIZE = 100 * 1024  # extra padding over spec for our wrapper

--- a/events/queue.py
+++ b/events/queue.py
@@ -2,6 +2,8 @@ import time
 
 import sysv_ipc
 
+from .const import MAXIMUM_EVENT_SIZE
+
 
 # how long to sleep when no items are in the message queue (seconds)
 BUSY_WAIT = 0.05
@@ -30,7 +32,7 @@ class SysVMessageQueue(object):
             key=key,
             flags=sysv_ipc.IPC_CREAT,
             mode=0600,
-            max_message_size=5120
+            max_message_size=MAXIMUM_EVENT_SIZE,
         )
 
     def put(self, event):


### PR DESCRIPTION
We missed a place where the maximum event size needed to be updated because I didn't use a single constant for both of them. This fixes that.

:eyeglasses: @Deimos @Kaitaan 