### PR TITLE
Categorize graphite metrics by client key + Local dev environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ virtualenv:
 before_install:
     - sudo add-apt-repository -y ppa:reddit/ppa
     - sudo apt-get update -qq
-    - sudo apt-get install -y -qq python-baseplate python-pyramid python-kafka python-nose python-mock python-coverage
+    - sudo apt-get install -y -qq python-baseplate python-pyramid python-kafka python-nose python-coverage
 
 script: nosetests

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "trusty-cloud-image"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.network "private_network", type: "dhcp"
+  config.vm.hostname = "event-collector.local"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "8096"]
+  end
+
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "./puppet"
+    puppet.manifest_file = "init.pp"
+    puppet.module_path = "./puppet/modules"
+    puppet.facter = {
+      "user" => "vagrant",
+      "project_path" => "/home/vagrant/event-collector",
+    }
+  end
+
+  config.vm.synced_folder  ".", "/home/vagrant/event-collector"
+end

--- a/puppet/README.md
+++ b/puppet/README.md
@@ -1,0 +1,7 @@
+This directory contains puppet manifests that configure a development
+environment for the event collector service.
+
+These manifests are applied automatically if you use Vagrant. To apply them
+manually, run the following from the root of the project:
+
+    sudo FACTER_user=$USER FACTER_project_path=$PWD puppet apply --modulepath puppet/modules puppet/init.pp

--- a/puppet/init.pp
+++ b/puppet/init.pp
@@ -1,0 +1,11 @@
+Exec { path => [ '/usr/bin', '/usr/sbin', '/bin', '/usr/local/bin' ] }
+
+exec { 'update apt cache':
+  command     => 'apt-get update',
+  refreshonly => true,
+}
+
+# make updating the apt cache an implicit requirement for all packages
+Exec['update apt cache'] -> Package<| |>
+
+include event_collector

--- a/puppet/modules/event_collector/manifests/init.pp
+++ b/puppet/modules/event_collector/manifests/init.pp
@@ -11,7 +11,6 @@ class event_collector {
     'python-coverage',
     'python-gevent',
     'python-kafka',
-    'python-mock',
     'python-nose',
     'python-pyramid',
     'python-setuptools',

--- a/puppet/modules/event_collector/manifests/init.pp
+++ b/puppet/modules/event_collector/manifests/init.pp
@@ -1,0 +1,30 @@
+class event_collector {
+  exec { 'add reddit ppa':
+    command => 'add-apt-repository -y ppa:reddit/ppa',
+    unless  => 'apt-cache policy | grep reddit/ppa',
+    notify  => Exec['update apt cache'],
+  }
+
+  $dependencies = [
+    'python',
+    'python-baseplate',
+    'python-coverage',
+    'python-gevent',
+    'python-kafka',
+    'python-mock',
+    'python-nose',
+    'python-pyramid',
+    'python-setuptools',
+  ]
+
+  package { $dependencies:
+    ensure => installed,
+    before => Exec['install app'],
+  }
+
+  exec { 'install app':
+    user    => $::user,
+    cwd     => $::project_path,
+    command => 'python setup.py develop --user',
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,6 @@ setup(
         "baseplate",
         "kafka-python",
     ],
-    tests_require=[
-        "mock",
-    ],
     entry_points={
         "paste.app_factory": [
             "main = events.collector:make_app",

--- a/tests/collector_tests.py
+++ b/tests/collector_tests.py
@@ -37,7 +37,7 @@ class MockSink(object):
         self.events.append(event)
 
 
-class MockTransport(baseplate.metrics.Transport):
+class MockMetricsTransport(baseplate.metrics.Transport):
     def __init__(self):
         self.metrics = []
 
@@ -65,7 +65,7 @@ class CollectorUnitTests(unittest.TestCase):
         self.event_sink = MockSink()
         self.error_sink = MockSink()
 
-        self.metrics = MockTransport()
+        self.metrics = MockMetricsTransport()
         metrics_client = baseplate.metrics.Client(self.metrics, "collector")
 
         self.allowed_origins = []


### PR DESCRIPTION
Now that we have a bunch of clients, it's useful to break down metrics per client. This will make it so that event collection volume and error rates are both segmented by the auth key being used, effectively letting us see which client is doing what. Hopefully this helps diagnosis of event errors without having to dig into logs or kafka.

I'll be doing another pull request to make the events going onto the error topic a bit more interesting as per IO-712.

:eyeglasses: @ckwang8128 @dellis23 

cc: @Kaitaan 