### PR TITLE
Put more information into error topic on Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Writing a client for this service? Check out the [API specification](https://git
 On Linux, you'll need to tune the POSIX Message Queue limits:
 
 ```shell
-echo 'fs.mqueue.msgsize_max = 102400' >> /etc/sysctl.conf # maximum size of an individual message, bytes
+echo 'fs.mqueue.msgsize_max = 512000' >> /etc/sysctl.conf # maximum size of an individual message, bytes
 echo 'fs.mqueue.msg_max = 65536' >> /etc/sysctl.conf # maximum number of messages in a queue
 ```

--- a/events/const.py
+++ b/events/const.py
@@ -1,7 +1,19 @@
 # if these constants change, make sure to update the sysctls and rlimits.
 
+# maximum size of a batch of events
+MAXIMUM_BATCH_SIZE = 500 * 1024
+
 # maximum size of a single event
 MAXIMUM_EVENT_SIZE = 100 * 1024
 
-# maximum length (in message count) of a queue
-MAXIMUM_QUEUE_LENGTH = 65536
+# maximum size of a message in a given queue
+MAXIMUM_MESSAGE_SIZE = {
+    "events": MAXIMUM_EVENT_SIZE,
+    "errors": MAXIMUM_BATCH_SIZE,
+}
+
+# maximum length (in message count) of a given queue
+MAXIMUM_QUEUE_LENGTH = {
+    "events": 65536,
+    "errors": 1024,
+}

--- a/events/injector.py
+++ b/events/injector.py
@@ -13,7 +13,7 @@ from kafka import KafkaClient, SimpleProducer
 from kafka.common import KafkaError
 from kafka.protocol import CODEC_GZIP
 
-from .const import MAXIMUM_QUEUE_LENGTH, MAXIMUM_EVENT_SIZE
+from .const import MAXIMUM_QUEUE_LENGTH, MAXIMUM_MESSAGE_SIZE
 
 
 _LOG = logging.getLogger(__name__)
@@ -37,8 +37,11 @@ def main():
     logging.config.fileConfig(config["__file__"])
 
     queue_name = os.environ["QUEUE"]
-    queue = MessageQueue("/" + queue_name,
-        max_messages=MAXIMUM_QUEUE_LENGTH, max_message_size=MAXIMUM_EVENT_SIZE)
+    queue = MessageQueue(
+        "/" + queue_name,
+        max_messages=MAXIMUM_QUEUE_LENGTH[queue_name],
+        max_message_size=MAXIMUM_MESSAGE_SIZE[queue_name],
+    )
 
     metrics_client = baseplate.make_metrics_client(config)
 


### PR DESCRIPTION
This includes the client's key and the raw batch payload from the client
(truncated to a safe length) to improve diagnostics.

Because the error topic is now potentially carrying whole batches in its
payload, the error queue needs large message sizes.

Example message on error topic:

```json
{
  "ip": "127.0.0.1",
  "event": {
    "raw_batch": "[{\"event_ts\": 1452641716146, \"uuid\": \"e049c97a-e647-4c69-b097-47dcf70bb336\", "payload\": {\"foobar\": \"foobar\"}, \"event_type\": \"cs.screenview\", \"event_topic\": "screenview_events\"}]",
    "key": "Test",
    "error": "INVALID_MAC"
  }, 
  "time": "2016-09-27T21:06:39.073182"
}
```

This is in addition to the previous improvements to granularity of the Graphite metrics which would cause a counter named `eventcollector.client-error.Test.INVALID_MAC` to be incremented in this example case, showing that the `Test` keyed client hit an `INVALID_MAC` error.

:eyeglasses: @dellis23 @ckwang8128 @Kaitaan 