### PR TITLE
Protect against bad unicode when serializing error payload

### DIFF
--- a/events/collector.py
+++ b/events/collector.py
@@ -148,7 +148,8 @@ class EventCollector(object):
         self.metrics_client.counter(metric_name).increment()
 
         # the -100 allows some room for the wrapper
-        truncated_body = request.body[:MAXIMUM_BATCH_SIZE-100]
+        unicode_body = request.body.decode("utf8", "replace")
+        truncated_body = unicode_body[:MAXIMUM_BATCH_SIZE-100]
         error = wrap_and_serialize_event(request, {
             "key": keyname,
             "error": code,


### PR DESCRIPTION
Since we started putting the whole bad batch's payload into the error
topic as JSON, we became susceptible to crashing when trying to put bad
unicode in. This patch protects against this issue by replacing bad
codepoints with the replacement character so we can at least see
something bad was there.

(This fixes IO-811)

:eyeglasses: @ckwang8128 @dellis23 