### PR TITLE
Force producers to use Kafka 0.8.2 APIs only

### DIFF
--- a/events/injector.py
+++ b/events/injector.py
@@ -71,7 +71,8 @@ def main():
         "batch_size": 20,
         "linger_ms": 10,
         "retries": int(config["kafka_retries"]),
-        "retry_backoff_ms": _RETRY_DELAY_SECS * 1000
+        "retry_backoff_ms": _RETRY_DELAY_SECS * 1000,
+        "api_version": "0.8.2"
     }
 
     def producer_error_cb(msg, queue):


### PR DESCRIPTION
👓  @spladug @ckwang8128 @kjoconnor

@kjoconnor This is related to what we were talking about this morning.

This is fairly significant for a one line change. I'll try to explain the reasoning behind it below.

The main issue we've encountered with the Kafka upgrade is that request handlers on the 0.10 brokers are using a lot more memory than they did on the 0.8 brokers. Further digging into heap snapshots showed that this memory usage is largely from Kafka's network receive buffers.

Complicating this matter is the fact that the kafka-python library auto-detects what version of the Kafka protocol to follow in the producers. See [here](http://kafka-python.readthedocs.io/en/1.0.2/apidoc/KafkaProducer.html) for documentation (look for `api_version`). The 1.0.2 version of kafka-python supports up to Kafka 0.9, and uses the 0.9 protocol to send data to 0.10 brokers. We confirmed this by looking at the staging Kafka broker which already runs 0.10.

This code change will force all producers to use the 0.8.2 protocol for producing, so that we can eliminate any weirdness from the producer using different protocols for different brokers (and possibly any bugs).

If any of you can guide me on how to test this that would be great :)